### PR TITLE
Update gpupicker for THREE 0.127.0

### DIFF
--- a/gpupicker.js
+++ b/gpupicker.js
@@ -38,7 +38,8 @@ var GPUPicker = function(three, renderer, scene, camera) {
     camera.setViewOffset(w, h, x, y, 1, 1);
 
     var currRenderTarget = renderer.getRenderTarget();
-    var currClearColor = renderer.getClearColor();
+    var currClearColor = new THREE.Color();
+    renderer.getClearColor(currClearColor);
     renderer.setRenderTarget(pickingTarget);
     renderer.setClearColor(clearColor);
     renderer.clear();
@@ -55,7 +56,7 @@ var GPUPicker = function(three, renderer, scene, camera) {
   function renderList() {
     // This is the magic, these render lists are still filled with valid data.  So we can
     // submit them again for picking and save lots of work!
-    var renderList = renderer.renderLists.get(scene, camera);
+    var renderList = renderer.renderLists.get(scene, 0);
     renderList.opaque.forEach(item => processItem(item));
     renderList.transparent.forEach(item => processItem(item));
   }


### PR DESCRIPTION
I love this lib! So simple and clear!

I made two changes for compatibility with THREE 0.127.0.

1) getClearColor() now wants you to pass in a target, else it logs a warning.
2) renderLists.get() now has a new signature.

2) is a breaking change, so maybe don't merge this PR as is.

They changed renderLists.get() in this commit: https://github.com/mrdoob/three.js/commit/4c181627c9950df273a8a74540f438cd9601ee10. I don't fully understand the meaning of `renderCallDepth`. I think it has to do with calling render from inside of another render. So, `0` may not always be the correct arg to use, but it probably works in most cases?